### PR TITLE
fix(prepare): use yarn to update package version

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -8,8 +8,8 @@ module.exports = async (npmrc, {tarballDir, pkgRoot}, {cwd, env, stdout, stderr,
   logger.log('Write version %s to package.json in %s', version, basePath);
 
   const versionResult = execa(
-    'npm',
-    ['version', version, '--userconfig', npmrc, '--no-git-tag-version', '--allow-same-version'],
+    'yarn',
+    ['version', version],
     {
       cwd: basePath,
       env,


### PR DESCRIPTION
So that npm doesn't fail for wront peer-dependencies requirements and avoid the error `@memobank/X' is not in this registry.`