### PR TITLE
Don't run prepare task before publish

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,10 +89,6 @@ async function publish(pluginConfig, context) {
     throw new AggregateError(errors);
   }
 
-  if (!prepared) {
-    await prepareNpm(npmrc, pluginConfig, context);
-  }
-
   return publishNpm(npmrc, pluginConfig, pkg, context);
 }
 


### PR DESCRIPTION
To let use `yarn version` as a prepare step without using this package, and keep this package only for the publish step.